### PR TITLE
Add graphviz dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>graphviz</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>doxygen</buildtool_export_depend>
   <build_export_depend>doxygen</build_export_depend>


### PR DESCRIPTION
> Solves one step of [maliput#283](https://github.com/ToyotaResearchInstitute/maliput/issues/283)

This PR adds the `graphviz` dependency in the `package.xml` file.