### PR TITLE
Suppress warnings in focal by removing extra keys.

### DIFF
--- a/resources/Doxyfile.in
+++ b/resources/Doxyfile.in
@@ -130,7 +130,7 @@ RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO
@@ -302,12 +302,10 @@ GENERATE_TAGFILE       = "@GENERATE_TAGFILE@"
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
-PERL_PATH              =
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = NO
-MSCGEN_PATH            =
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = NO
 HAVE_DOT               = @HAVE_DOT@


### PR DESCRIPTION
Warnings are due to PERL_PATH and MSCGEN_PATH which were empty keys and deprecated in doxygen 1.8.17 which comes with focal vs doxygen 1.8.13 which comes in bionic.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196