### PR TITLE
Adds flag to enable warnings check as a test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,6 @@ ament_package(
 )
 
 install(
-  DIRECTORY cmake resources
+  DIRECTORY cmake resources tools
   DESTINATION share/${PROJECT_NAME}
 )

--- a/ament_cmake_doxygen-extras.cmake
+++ b/ament_cmake_doxygen-extras.cmake
@@ -16,6 +16,7 @@ find_package(ament_cmake_core REQUIRED)
 find_package(Doxygen REQUIRED)
 
 set(AMENT_CMAKE_DOXYGEN_RESOURCES_DIR "${ament_cmake_doxygen_DIR}/../resources")
+set(AMENT_CMAKE_DOXYGEN_TOOLS_DIR "${ament_cmake_doxygen_DIR}/../tools")
 
 include("${ament_cmake_doxygen_DIR}/ament_doxygen_resolve_tags.cmake")
 include("${ament_cmake_doxygen_DIR}/ament_doxygen_find_external.cmake")

--- a/cmake/ament_doxygen_generate.cmake
+++ b/cmake/ament_doxygen_generate.cmake
@@ -54,13 +54,15 @@
 #                      these must have been installed. See ament_doxygen_find_external() documentation
 #                      for further reference.
 # :type DEPENDENCIES: list of strings
+# :param TEST_ON_WARNS: Verify null presence of doxygen-format related warnings by adding a test.
+# :type TEST_ON_WARNS: boolean
 #
 # @public
 #
 function(ament_doxygen_generate target_name)
   cmake_parse_arguments(
     args
-    "STANDALONE;NO_INSTALL"
+    "STANDALONE;NO_INSTALL;TEST_ON_WARNS"
     "PROJECT_NAME;CONFIG_OVERLAY;CONFIG_DIRECTORY;INPUT_DIRECTORY;BUILD_DIRECTORY;INSTALL_DIRECTORY"
     "DEPENDENCIES" ${ARGN})
 
@@ -158,4 +160,13 @@ function(ament_doxygen_generate target_name)
     )
     set(${target_name}_DEPENDENCIES "${args_DEPENDENCIES}" PARENT_SCOPE)
   endif()
+
+  if (args_TEST_ON_WARNS)
+  set(warning_log "${args_CONFIG_DIRECTORY}/warnings.log")
+    add_test(
+      NAME ${PROJECT_NAME}_doxygen_warnings
+      COMMAND bash "${AMENT_CMAKE_DOXYGEN_TOOLS_DIR}/check_doc_warns.sh" "${warning_log}"
+    )
+  endif()
+
 endfunction()

--- a/tools/check_doc_warns.sh
+++ b/tools/check_doc_warns.sh
@@ -1,0 +1,19 @@
+# Copyright 2021 Toyota Research Institute
+#! /bin/bash
+
+# Inspired on https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/tools/doc_check.sh.
+
+WARNINGS_LOG_FILE=$1
+
+if [ -f $WARNINGS_LOG_FILE ]; then
+  if [ -s $WARNINGS_LOG_FILE ]; then
+    echo "Error. The following warnings were found in $WARNINGS_LOG_FILE."
+    cat $WARNINGS_LOG_FILE
+    exit 1
+  else
+    echo "Success. No warnings found in $WARNINGS_LOG_FILE"
+    exit 0
+  fi
+else
+  echo "The $WARNINGS_LOG_FILE file does not exist. Skipping doc check."
+fi


### PR DESCRIPTION
#### New Feature:

When passing `TEST_ON_WARNS` flag to the `ament_doxygen_generate` macro, a test will be added to check the `warnings.log` file created out of the generation of documentation by `doxygen`.
 - Test will fail if warnings are present
 - Warnings will be printed